### PR TITLE
fix: update back button design

### DIFF
--- a/app/src/pages/ContentItemPage.tsx
+++ b/app/src/pages/ContentItemPage.tsx
@@ -3,7 +3,8 @@ import { ContentItemEditor } from "@/components/Content/ContentItemEditor";
 import { useParams, useNavigate } from "react-router-dom";
 import { ContentItem, ContentItemStatus, ContentItemComment } from "@/lib/contentSchema";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, MessageSquare, Send, ThumbsUp, ThumbsDown, Plus, Reply, ArrowRight } from "lucide-react";
+import { ChevronLeft, MessageSquare, Send, ThumbsUp, ThumbsDown, Plus, Reply, ArrowRight } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -381,10 +382,17 @@ const ContentItemPage: React.FC = () => {
       <div className="flex items-center justify-center h-64">
         <div className="text-center">
           <p className="text-destructive mb-4">Error loading content</p>
-          <Button onClick={() => navigate('/manager')}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Manager
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button onClick={() => navigate('/manager')} variant="ghost" size="icon">
+                  <ChevronLeft className="h-4 w-4" />
+                  <span className="sr-only">Back</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent />
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
     );
@@ -396,10 +404,17 @@ const ContentItemPage: React.FC = () => {
       <div className="flex items-center justify-center h-64">
         <div className="text-center">
           <p className="text-muted-foreground mb-4">Schema not found</p>
-          <Button onClick={() => navigate('/manager')}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Manager
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button onClick={() => navigate('/manager')} variant="ghost" size="icon">
+                  <ChevronLeft className="h-4 w-4" />
+                  <span className="sr-only">Back</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent />
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
     );
@@ -418,15 +433,21 @@ const ContentItemPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto p-6 space-y-6">
       <div className="flex items-center gap-4">
-        <Button 
-          variant="ghost" 
-          size="sm" 
-          onClick={() => navigate('/manager')}
-          className="gap-2"
-        >
-          <ArrowLeft size={16} />
-          Back to Manager
-        </Button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => navigate('/manager')}
+              >
+                <ChevronLeft size={16} />
+                <span className="sr-only">Back</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent />
+          </Tooltip>
+        </TooltipProvider>
         
         <div className="flex-1">
           <h1 className="text-2xl font-bold">


### PR DESCRIPTION
## Summary
- use ChevronLeft icon for ContentItemPage back actions
- show caret icon button with tooltip that has no text

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723b092ff483309aefca495d116d6e