### PR TITLE
fix: default new schema as collection

### DIFF
--- a/app/src/components/Content/ContentSchemaEditor.tsx
+++ b/app/src/components/Content/ContentSchemaEditor.tsx
@@ -28,7 +28,7 @@ export const ContentSchemaEditor: React.FC<ContentSchemaEditorProps> = ({
       name: "",
       description: "",
       fields: [],
-      type: "single" as const,
+      type: "collection" as const,
     }
   );
 


### PR DESCRIPTION
## Summary
- ensure new schemas default to collection type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(not run due to failed dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_687231dbb38883309769813cef249089