### PR TITLE
fix: address lint errors in tests

### DIFF
--- a/app/tests/contexts/WorkspaceContext.test.tsx
+++ b/app/tests/contexts/WorkspaceContext.test.tsx
@@ -7,6 +7,7 @@ vi.unmock("../../src/lib/contexts/WorkspaceContext");
 vi.mock("swr", () => ({ default: vi.fn() }));
 vi.mock("../../src/lib/api/WorkspaceApi");
 
+import swr from "swr";
 import { WorkspaceProvider, useWorkspace } from "../../src/lib/contexts/WorkspaceContext";
 
 const mockWorkspaces = [
@@ -20,7 +21,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe("WorkspaceContext", () => {
   beforeEach(() => {
-    const mockUseSWR = vi.mocked(require("swr").default);
+    const mockUseSWR = vi.mocked(swr);
     mockUseSWR.mockImplementation(() => ({
       data: mockWorkspaces,
       error: null,

--- a/app/tests/lib/CommentsApi.test.ts
+++ b/app/tests/lib/CommentsApi.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import type { Comment } from '@/types/comments';
 import { initializeStorage, getComments, getCommentById, getCommentsByContentItem, getPendingComments, saveComment, approveComment, getThreadedComments } from '../../src/lib/api/CommentsApi';
 
 // Mock localStorage
@@ -128,12 +130,12 @@ describe('CommentsApi', () => {
   describe('saveComment', () => {
     it('should add a new comment', async () => {
       localStorage.getItem = vi.fn().mockReturnValue(JSON.stringify([]));
-      const newComment = { ...testComment, id: undefined as any };
+      const newComment: Partial<Comment> = { ...testComment, id: undefined };
       
       await saveComment(newComment);
       
       expect(localStorage.setItem).toHaveBeenCalled();
-      const savedComments = JSON.parse((localStorage.setItem as any).mock.calls[0][1]);
+      const savedComments = JSON.parse((localStorage.setItem as Mock).mock.calls[0][1] as string);
       expect(savedComments.length).toBe(1);
       expect(savedComments[0].id).toBe('test-uuid');
     });
@@ -149,7 +151,7 @@ describe('CommentsApi', () => {
       await saveComment(updatedComment);
       
       expect(localStorage.setItem).toHaveBeenCalled();
-      const savedComments = JSON.parse((localStorage.setItem as any).mock.calls[0][1]);
+      const savedComments = JSON.parse((localStorage.setItem as Mock).mock.calls[0][1] as string);
       expect(savedComments.length).toBe(1);
       expect(savedComments[0].text).toBe('Updated comment text');
       expect(new Date(savedComments[0].updatedAt).toISOString()).toBe(savedComments[0].updatedAt);
@@ -163,7 +165,7 @@ describe('CommentsApi', () => {
       await approveComment('test-comment-id');
       
       expect(saveComment).toHaveBeenCalled();
-      const savedComment = (saveComment as any).mock.calls[0][0];
+      const savedComment = (saveComment as Mock).mock.calls[0][0];
       expect(savedComment.status).toBe('approved');
     });
 

--- a/app/tests/pages/Dashboard.test.tsx
+++ b/app/tests/pages/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 /// <reference types="vitest/globals" />
 import React from "react";
-import { describe, test, expect, vi, beforeEach, Mock } from "vitest";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 import { screen, within } from "@testing-library/react";
 import { render } from "../utils/test-utils";
 import Dashboard from "../../src/pages/Dashboard";
@@ -76,13 +77,13 @@ describe("Dashboard", () => {
 
   describe("Empty States", () => {
     beforeEach(() => {
-      (ContentApi.listContentItems as any).mockResolvedValue([]);
+      (ContentApi.listContentItems as Mock).mockResolvedValue([]);
     });
 
     test("renders empty state for Last Edited widget", async () => {
       render(<Dashboard />);
 
-      const emptyState = await screen.findByText("No recent activity");
+      await screen.findByText("No recent activity");
       await screen.findByText("Content you edit will appear here");
       expect(screen.queryByRole("link", { name: /view more/i })).toBeNull();
     });
@@ -90,7 +91,7 @@ describe("Dashboard", () => {
     test("renders empty state for Draft Content widget", async () => {
       render(<Dashboard />);
 
-      const emptyState = await screen.findByText("No draft content");
+      await screen.findByText("No draft content");
       await screen.findByText("Content you save as draft will appear here");
       expect(screen.queryByRole("link", { name: /view more/i })).toBeNull();
     });
@@ -98,7 +99,7 @@ describe("Dashboard", () => {
     test("renders empty state for Published Content widget", async () => {
       render(<Dashboard />);
 
-      const emptyState = await screen.findByText("No published content");
+      await screen.findByText("No published content");
       await screen.findByText("Content you publish will appear here");
       expect(screen.queryByRole("link", { name: /view more/i })).toBeNull();
     });
@@ -106,7 +107,7 @@ describe("Dashboard", () => {
     test("renders empty state for Approval Requests widget", async () => {
       render(<Dashboard />);
 
-      const emptyState = await screen.findByText("No content to review");
+      await screen.findByText("No content to review");
       await screen.findByText(
         "Content waiting for your review will appear here"
       );
@@ -116,7 +117,7 @@ describe("Dashboard", () => {
 
   describe("Content Rendering", () => {
     beforeEach(() => {
-      (ContentApi.listContentItems as any).mockResolvedValue(mockContentItems);
+      (ContentApi.listContentItems as Mock).mockResolvedValue(mockContentItems);
     });
 
     test("renders content items in Last Edited widget", async () => {
@@ -183,7 +184,7 @@ describe("Dashboard", () => {
 
   describe("View More Navigation", () => {
     beforeEach(() => {
-      (ContentApi.listContentItems as any).mockResolvedValue(mockContentItems);
+      (ContentApi.listContentItems as Mock).mockResolvedValue(mockContentItems);
     });
 
     test("navigates to correct route when clicking View More in Last Edited widget", async () => {

--- a/app/tests/types.d.ts
+++ b/app/tests/types.d.ts
@@ -1,11 +1,16 @@
 /// <reference types="@testing-library/jest-dom" />
 
 declare module '@testing-library/jest-dom/vitest' {
-  import { Assertion, AsymmetricMatchersContaining } from 'vitest';
   interface CustomMatchers<R = unknown> {
     toBeInTheDocument(): R;
     toHaveValue(value: string | string[] | number | null): R;
   }
-  interface Matchers<R> extends CustomMatchers<R> {}
-  interface AsymmetricMatchers extends CustomMatchers {}
-} 
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Matchers<R> extends CustomMatchers<R> {
+    // Additional jest-dom matchers can be added here in the future
+  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface AsymmetricMatchers extends CustomMatchers {
+    // Additional asymmetric matchers can be added here in the future
+  }
+}


### PR DESCRIPTION
Updated test files to satisfy ESLint rules. Replaced CommonJS require usage, removed unused variables, typed mocks, and tweaked type declarations.

Linting could not run because dependencies are missing in this environment.

------
https://chatgpt.com/codex/tasks/task_e_6872e886df58833090b71759ad8550f3