### PR TITLE
Add test for data migrations

### DIFF
--- a/app/tests/data.test.ts
+++ b/app/tests/data.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Provide a compileTime stub similar to vite-plugin-compile-time
+(globalThis as any).compileTime = async (fn: any) => fn();
+
+const mockSqlFile = '20240101010101_test.sql';
+const mockSqlContent = 'SELECT 1;';
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(() => true),
+    readdirSync: vi.fn(() => [mockSqlFile]),
+    readFileSync: vi.fn(() => mockSqlContent)
+  }
+}));
+
+vi.mock('path', async () => {
+  const actual = await vi.importActual<typeof import('path')>('path');
+  return { default: actual };
+});
+
+let migrationsModule: typeof import('../src/data');
+
+beforeEach(async () => {
+  vi.resetModules();
+  migrationsModule = await import('../src/data');
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('migrations', () => {
+  it('loads migrations from the filesystem', async () => {
+    const result = await (migrationsModule.migrations as any);
+    expect(result).toEqual([
+      {
+        version: '20240101010101',
+        name: 'test',
+        filename: `supabase/migrations/${mockSqlFile}`,
+        sql: mockSqlContent,
+        workspace: 'supabase'
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest for app/src/data.ts

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b415c610833096a9c6f2e10cfb35