### PR TITLE
feat: unify back button component

### DIFF
--- a/app/src/components/ui/BackIconButton.tsx
+++ b/app/src/components/ui/BackIconButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+
+interface BackIconButtonProps {
+  label: string;
+  onClick: () => void;
+  className?: string;
+}
+
+export const BackIconButton: React.FC<BackIconButtonProps> = ({ label, onClick, className }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" onClick={onClick} className={className}>
+          <ChevronLeft size={16} />
+          <span className="sr-only">{label}</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/app/src/pages/ContentItemPage.tsx
+++ b/app/src/pages/ContentItemPage.tsx
@@ -3,8 +3,9 @@ import { ContentItemEditor } from "@/components/Content/ContentItemEditor";
 import { useParams, useNavigate } from "react-router-dom";
 import { ContentItem, ContentItemStatus, ContentItemComment } from "@/lib/contentSchema";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, MessageSquare, Send, ThumbsUp, ThumbsDown, Plus, ArrowRight } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { MessageSquare, Send, ThumbsUp, ThumbsDown, Plus, ArrowRight } from "lucide-react";
+
+import { BackIconButton } from "@/components/ui/BackIconButton";
 import { useToast } from "@/hooks/use-toast";
 import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -378,17 +379,7 @@ const ContentItemPage: React.FC = () => {
       <div className="flex items-center justify-center h-64">
         <div className="text-center">
           <p className="text-destructive mb-4">Error loading content</p>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button onClick={() => navigate('/manager')} variant="ghost" size="icon">
-                  <ChevronLeft className="h-4 w-4" />
-                  <span className="sr-only">Back</span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent />
-            </Tooltip>
-          </TooltipProvider>
+          <BackIconButton label="Back to manager" onClick={() => navigate('/manager')} />
         </div>
       </div>
     );
@@ -400,17 +391,7 @@ const ContentItemPage: React.FC = () => {
       <div className="flex items-center justify-center h-64">
         <div className="text-center">
           <p className="text-muted-foreground mb-4">Schema not found</p>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button onClick={() => navigate('/manager')} variant="ghost" size="icon">
-                  <ChevronLeft className="h-4 w-4" />
-                  <span className="sr-only">Back</span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent />
-            </Tooltip>
-          </TooltipProvider>
+          <BackIconButton label="Back to manager" onClick={() => navigate('/manager')} />
         </div>
       </div>
     );
@@ -429,21 +410,7 @@ const ContentItemPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto p-6 space-y-6">
       <div className="flex items-center gap-4">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => navigate('/manager')}
-              >
-                <ChevronLeft size={16} />
-                <span className="sr-only">Back</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent />
-          </Tooltip>
-        </TooltipProvider>
+        <BackIconButton label="Back to manager" onClick={() => navigate('/manager')} />
         
         <div className="flex-1">
           <h1 className="text-2xl font-bold">

--- a/app/src/pages/SchemaEditorPage.tsx
+++ b/app/src/pages/SchemaEditorPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
-  ArrowLeft,
   Plus,
   Type,
   Hash,
@@ -62,6 +61,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { BackIconButton } from "@/components/ui/BackIconButton";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -896,15 +896,7 @@ const SchemaEditorPage: React.FC = () => {
       <div className="flex items-center justify-between">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate(-1)}
-              className="gap-2"
-            >
-              <ArrowLeft size={16} />
-              Back
-            </Button>
+            <BackIconButton label="Back" onClick={() => navigate(-1)} />
             <h1 className="text-2xl font-bold">{schema.name}</h1>
             <Badge
               variant={schema.type === "collection" ? "default" : "outline"}


### PR DESCRIPTION
- added BackIconButton for shared back navigation
- replaced manual back buttons on editor pages with the new component
- each page now shows a tooltip with its own label

------
https://chatgpt.com/codex/tasks/task_e_68736fe9f6108330a0aecde960246f0e