### PR TITLE
chore: clean pr description

### DIFF
--- a/.github/workflows/clean-pr-description.yml
+++ b/.github/workflows/clean-pr-description.yml
@@ -1,0 +1,33 @@
+name: Clean PR Description
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove chatgpt.com link and divider
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            let body = pr.body || '';
+            body = body
+              .replace(/https?:\/\/chatgpt\.com\S*/g, '')
+              .replace(/^---+$/gm, '')
+              .replace(/\n{2,}/g, '\n')
+              .trim();
+            if (body !== (pr.body || '').trim()) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                body
+              });
+            }
+


### PR DESCRIPTION
- add workflow that removes chatgpt.com link and divider from PR body
- run on every opened pull request
- use actions/github-script to update description

------
https://chatgpt.com/codex/tasks/task_e_6873945d542c83308d895accc7232c3a