### PR TITLE
chore: cache node modules

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -23,6 +23,14 @@ jobs:
             app/package-lock.json
             web/package-lock.json
             shared/package-lock.json
+      - name: Restore node_modules cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            app/node_modules
+            web/node_modules
+            shared/node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('app/package-lock.json', 'web/package-lock.json', 'shared/package-lock.json') }}
       - name: Install dependencies on shared
         run: npm ci
         working-directory: shared

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -33,12 +33,13 @@ jobs:
           node-version: "22.9"
           cache: npm
           cache-dependency-path: '**/package-lock.json'
-      - name: Restore cache
+      - name: Restore node_modules cache
         uses: actions/cache@v3
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-web-build-${{ hashFiles('**/package-lock.json') }}
+            ../shared/node_modules
+          key: ${{ runner.os }}-app-build-${{ hashFiles('app/package-lock.json', 'shared/package-lock.json') }}
       - name: Install dependencies on shared
         run: npm ci
         working-directory: shared

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -33,12 +33,13 @@ jobs:
           node-version: "22.9"
           cache: npm
           cache-dependency-path: '**/package-lock.json'
-      - name: Restore cache
+      - name: Restore node_modules cache
         uses: actions/cache@v3
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-web-build-${{ hashFiles('**/package-lock.json') }}
+            ../shared/node_modules
+          key: ${{ runner.os }}-web-build-${{ hashFiles('web/package-lock.json', 'shared/package-lock.json') }}
       - name: Install dependencies on shared
         run: npm ci
         working-directory: shared


### PR DESCRIPTION
- cache app, web, and shared `node_modules` in build-check
- add shared cache paths in deploy workflows