### PR TITLE
feat: enable quickstart templates

### DIFF
--- a/app/src/components/Dashboard/QuickstartTemplateDialog.tsx
+++ b/app/src/components/Dashboard/QuickstartTemplateDialog.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { TemplateService, TemplateType } from "@/lib/api/TemplateService";
+import { useWorkspace } from "@/lib/contexts/WorkspaceContext";
 
 interface QuickstartTemplateDialogProps {
   open: boolean;
@@ -20,6 +21,7 @@ export const QuickstartTemplateDialog: React.FC<QuickstartTemplateDialogProps> =
 }) => {
   const { toast } = useToast();
   const navigate = useNavigate();
+  const { currentWorkspace } = useWorkspace();
   const [isLoading, setIsLoading] = useState(false);
   
   if (!templateType) return null;
@@ -36,11 +38,12 @@ export const QuickstartTemplateDialog: React.FC<QuickstartTemplateDialogProps> =
   };
   
   const handleCreateTemplate = async () => {
+    if (!currentWorkspace) return;
     try {
       setIsLoading(true);
-      
+
       // Apply the template
-      await TemplateService.applyTemplate(templateType);
+      await TemplateService.applyTemplate(templateType, currentWorkspace.id);
       
       toast({
         title: "Template installed",

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -95,6 +95,8 @@ const Dashboard: React.FC = () => {
 
   const isLoading = contentLoading || recentEditedLoading || recentPublishedLoading || schemasLoading;
 
+  const showQuickstart = schemas.length === 0 && contentItems.length === 0;
+
   // Handle authentication check
   useEffect(() => {
     const loadUser = async () => {
@@ -345,7 +347,7 @@ const Dashboard: React.FC = () => {
       </div>
 
       {/* Quickstart Templates Section */}
-      {false && (
+      {showQuickstart && (
         <Card className="w-full">
           <CardHeader className="pb-3">
             <div className="flex items-center gap-3">


### PR DESCRIPTION
- show quickstart templates when workspace has no content
- seed schemas and items for each template via API
- update template descriptions with seeding info
- pass workspace id to template dialog