### PR TITLE
fix: restore arrow export for workspace dialog

### DIFF
--- a/app/src/components/Workspace/WorkspaceDeleteDialog.tsx
+++ b/app/src/components/Workspace/WorkspaceDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -22,13 +22,13 @@ interface WorkspaceDeleteDialogProps {
   isDeleting?: boolean;
 }
 
-export const WorkspaceDeleteDialog: React.FC<WorkspaceDeleteDialogProps> = ({
+export const WorkspaceDeleteDialog = ({
   open,
   onOpenChange,
   workspace,
   onConfirm,
   isDeleting = false,
-}) => {
+}: WorkspaceDeleteDialogProps) => {
   const [confirmText, setConfirmText] = useState("");
   const expectedText = "delete";
   const isConfirmValid = confirmText === expectedText;
@@ -115,4 +115,6 @@ export const WorkspaceDeleteDialog: React.FC<WorkspaceDeleteDialogProps> = ({
       </DialogContent>
     </Dialog>
   );
-}; 
+};
+
+export default WorkspaceDeleteDialog;


### PR DESCRIPTION
- revert WorkspaceDeleteDialog to arrow export and add default export for compatibility

------
https://chatgpt.com/codex/tasks/task_e_68d8b822b3048330b62802e3eec322a9